### PR TITLE
feat: make disabling options more versatile

### DIFF
--- a/apps/ui/src/lib/component/index.ts
+++ b/apps/ui/src/lib/component/index.ts
@@ -1,2 +1,3 @@
 export * from "./regenerateComponent";
 export * from "./mergeComponents";
+export * from "./resovleFinalGenOptions"

--- a/apps/ui/src/lib/component/regenerateComponent.ts
+++ b/apps/ui/src/lib/component/regenerateComponent.ts
@@ -11,6 +11,7 @@ import { SVG_PLACEHOLDER_PREFIX } from "../consts";
 import { generateOptimizedSvg } from "../svgo";
 import { formatComponent } from "./formatComponent";
 import { COMPONENT_GENERATORS } from "./generators";
+import { resolveFinalGenOptions } from "./resovleFinalGenOptions";
 
 interface IOpts {
 	originalSvg: IOriginalSvg;
@@ -25,29 +26,10 @@ export const regenerateComponent = async ({
 	framework,
 	originalSvg,
 }: IOpts): Promise<IComponent> => {
-	const genOptions = { ...ogGenOptions };
-
-	// resolve generation options values
-	for (const _optKey in GEN_OPTIONS_METADATA) {
-		const optKey = _optKey as IGenOptionsMetaKeys;
-		const meta = GEN_OPTIONS_METADATA[optKey];
-
-		if (genOptions[optKey]) {
-			if (!meta.frameworks.includes(framework)) {
-				genOptions[optKey] = false;
-			} else {
-				for (const required of meta.requiredSettings) {
-					if (
-						required.value !== ogGenOptions[required.optionKey] &&
-						(required.framework == null || required.framework === framework)
-					) {
-						genOptions[optKey] = false;
-						break;
-					}
-				}
-			}
-		}
-	}
+	const genOptions = resolveFinalGenOptions({
+		genOptions: ogGenOptions,
+		framework,
+	});
 
 	const { svgCode, svgDefaultValues, svgTransformationInfo } =
 		generateOptimizedSvg({

--- a/apps/ui/src/lib/component/resovleFinalGenOptions.ts
+++ b/apps/ui/src/lib/component/resovleFinalGenOptions.ts
@@ -1,0 +1,39 @@
+import { GEN_OPTIONS_METADATA } from "@shared/lib";
+import type {
+	FrameworkEnum,
+	IGenOptions,
+	IGenOptionsMetaKeys,
+} from "@shared/types";
+
+interface IOpts {
+	genOptions: IGenOptions;
+	framework: FrameworkEnum;
+}
+
+export const resolveFinalGenOptions = ({
+	genOptions: currentGenOptions,
+	framework,
+}: IOpts): IGenOptions => {
+	const genOptions: Partial<IGenOptions> = {};
+
+	for (const _optKey in GEN_OPTIONS_METADATA) {
+		const optKey = _optKey as IGenOptionsMetaKeys;
+		const meta = GEN_OPTIONS_METADATA[optKey];
+
+		genOptions[optKey] = false;
+
+		if (currentGenOptions[optKey]) {
+			if (meta.frameworks.includes(framework)) {
+				if (
+					!meta.disabledWhen ||
+					!meta.disabledWhen({ genOptions: currentGenOptions, framework })
+						.isDisabled
+				) {
+					genOptions[optKey] = true;
+				}
+			}
+		}
+	}
+
+	return genOptions as IGenOptions;
+};

--- a/apps/ui/src/modules/GenOptions/GenOptionRequirmentsPopUp.tsx
+++ b/apps/ui/src/modules/GenOptions/GenOptionRequirmentsPopUp.tsx
@@ -1,22 +1,54 @@
 import { Checkbox } from "@common/Checkbox";
-import { For } from "solid-js";
-import type { IRequiredOption } from "./GenOption";
+import { GEN_OPTIONS_METADATA } from "@shared/lib";
+import type { IGenOptionDisabledData, IGenOptionMeta } from "@shared/types";
+import { For, type JSXElement, createMemo } from "solid-js";
 
 interface IProps {
-	displayName: string;
-	requiredOptions: IRequiredOption[];
+	disabledData: IGenOptionDisabledData;
 }
 
 export const GenOptionRequirmentsPopUp = (props: IProps) => {
+	const reasons = createMemo(() => {
+		const items: JSXElement[][] = [];
+
+		for (const reason of props.disabledData.reasons) {
+			const parts = reason.split(/(<ON>|<OFF>|{[^}]+})/).filter(Boolean);
+			const item: JSXElement[] = [];
+
+			for (const part of parts) {
+				if (part === "<ON>") {
+					item.push(<Checkbox value={true} />);
+				} else if (part === "<OFF>") {
+					item.push(<Checkbox value={false} />);
+				} else if (part.startsWith("{") && part.endsWith("}")) {
+					const opt = GEN_OPTIONS_METADATA[part.replaceAll(/{|}/gm, "")] as
+						| IGenOptionMeta
+						| undefined;
+
+					item.push(
+						<div class="flex items-center justify-center rounded bg-gray-200 px-1.5 py-0.5">
+							{opt ? opt.displayName : part}
+						</div>,
+					);
+				} else {
+					item.push(part);
+				}
+			}
+
+			items.push(item);
+		}
+
+		return items;
+	}, [props.disabledData.reasons]);
+
 	return (
-		<aside class="absolute top-0 left-0 z-10 hidden w-64 flex-col rounded-sm border border-gray-300 bg-white p-1 text-black text-sm shadow-md group-hover:flex">
-			<span class="text-left">"{props.displayName}" requires:</span>
-			<ul class="mt-1 ml-2 grid gap-1 text-left">
-				<For each={props.requiredOptions}>
-					{(requiredOpt) => (
-						<li class="flex items-center space-x-1">
-							<span>{requiredOpt.meta.displayName}</span>
-							<Checkbox value={requiredOpt.value} />
+		<aside class="absolute top-0 left-0 z-10 hidden w-72 flex-col rounded-sm border border-gray-300 bg-white p-1 text-black text-sm shadow-md group-hover:flex">
+			<span class="w-full text-left">Option is disabled:</span>
+			<ul class="mt-1 grid gap-1 text-left">
+				<For each={reasons()}>
+					{(reason) => (
+						<li class="flex flex-wrap items-center justify-start gap-1">
+							- {reason}
 						</li>
 					)}
 				</For>

--- a/apps/ui/tests/resolveFinalGenOptions.test.ts
+++ b/apps/ui/tests/resolveFinalGenOptions.test.ts
@@ -1,0 +1,124 @@
+import { resolveFinalGenOptions } from "@lib";
+import {
+	GEN_OPTIONS_METADATA,
+	makeDefaultGenOptions,
+} from "@shared/lib";
+import { FrameworkEnum, type IGenOptionsMetaKeys } from "@shared/types";
+import { describe, expect, test } from "vitest";
+
+describe("util: resolve final generation options", () => {
+	for (const framework of Object.values(FrameworkEnum)) {
+		test(`[${framework}]: all options should be false`, () => {
+			const genOptions = {
+				...makeDefaultGenOptions(),
+			};
+			for (const key in genOptions) {
+				genOptions[key] = false;
+			}
+
+			for (const key in resolveFinalGenOptions({ genOptions, framework })) {
+				expect(genOptions[key]).toBe(false);
+			}
+		});
+
+		if (framework !== FrameworkEnum.SVG) {
+			const isForwardRefFalse = framework === FrameworkEnum.SOLID;
+			test(`[${framework}]: forwardRef should be ${!isForwardRefFalse}`, () => {
+				let genOptions = {
+					...makeDefaultGenOptions(),
+				};
+				for (const key in genOptions) {
+					genOptions[key] = false;
+				}
+
+				genOptions.props = true;
+				genOptions.spreadProps = true;
+				genOptions.forwardRef = true;
+
+				genOptions = resolveFinalGenOptions({
+					genOptions,
+					framework,
+				});
+
+				expect(genOptions.props).toBe(true);
+				expect(genOptions.spreadProps).toBe(true);
+				expect(genOptions.forwardRef).toBe(!isForwardRefFalse);
+			});
+
+			test(`[${framework}]: Props interface should be false`, () => {
+				let genOptions = {
+					...makeDefaultGenOptions(),
+				};
+				for (const key in genOptions) {
+					genOptions[key] = false;
+				}
+
+				genOptions.props = false;
+				genOptions.propsInterface = true;
+
+				genOptions = resolveFinalGenOptions({
+					genOptions,
+					framework,
+				});
+
+				expect(genOptions.props).toBe(false);
+				expect(genOptions.propsInterface).toBe(false);
+			});
+
+			test(`[${framework}]: Spread props should be false`, () => {
+				let genOptions = {
+					...makeDefaultGenOptions(),
+				};
+				for (const key in genOptions) {
+					genOptions[key] = false;
+				}
+
+				genOptions.props = false;
+				genOptions.spreadProps = true;
+
+				genOptions = resolveFinalGenOptions({
+					genOptions,
+					framework,
+				});
+
+				expect(genOptions.props).toBe(false);
+				expect(genOptions.spreadProps).toBe(false);
+			});
+		}
+	}
+
+	test(`[${FrameworkEnum.SVG}]: JSX options should be false`, () => {
+		let genOptions = {
+			...makeDefaultGenOptions(),
+		};
+		for (const key in genOptions) {
+			genOptions[key] = true;
+		}
+
+		genOptions = resolveFinalGenOptions({
+			genOptions,
+			framework: FrameworkEnum.SVG,
+		});
+
+		for (const key in GEN_OPTIONS_METADATA) {
+			const meta = GEN_OPTIONS_METADATA[key as IGenOptionsMetaKeys];
+			expect(genOptions[key]).toBe(meta.frameworks.includes(FrameworkEnum.SVG));
+		}
+	});
+
+	test(`[${FrameworkEnum.SOLID}]: React options should be false`, () => {
+		let genOptions = {
+			...makeDefaultGenOptions(),
+		};
+		for (const key in genOptions) {
+			genOptions[key] = true;
+		}
+
+		genOptions = resolveFinalGenOptions({
+			genOptions,
+			framework: FrameworkEnum.SOLID,
+		});
+
+		expect(genOptions.importAllAsReact).toBe(false);
+	});
+});

--- a/shared/lib/src/genOptions.ts
+++ b/shared/lib/src/genOptions.ts
@@ -21,93 +21,81 @@ export const GEN_OPTIONS_METADATA: IGenOptionsMeta = {
 	importAllAsReact: {
 		displayName: "Add: import * as React",
 		defaultValue: false,
-		requiredSettings: [],
 		frameworks: REACT_FRAMEWORKS,
 	},
 	typescript: {
 		displayName: "Typescript",
 		defaultValue: true,
-		requiredSettings: [],
 		frameworks: JSX_FRAMEWORKS,
 	},
 	props: {
 		displayName: "With props",
 		defaultValue: true,
-		requiredSettings: [],
 		frameworks: JSX_FRAMEWORKS,
 	},
 	spreadProps: {
 		displayName: "Spread props",
 		defaultValue: true,
-		requiredSettings: [{ optionKey: "props", value: true }],
+		disabledWhen: ({ genOptions }) => ({
+			isDisabled: !genOptions.props,
+			reasons: ["{props} must be <ON>"],
+		}),
 		frameworks: JSX_FRAMEWORKS,
 	},
 	propsInterface: {
 		displayName: "Props interface",
 		defaultValue: true,
-		requiredSettings: [
-			{ optionKey: "typescript", value: true },
-			{ optionKey: "props", value: true },
-		],
+		disabledWhen: ({ genOptions }) => ({
+			isDisabled: !genOptions.props,
+			reasons: ["{props} must be <ON>"],
+		}),
 		frameworks: JSX_FRAMEWORKS,
 	},
 	removeWidth: {
 		displayName: "Remove svg width",
 		defaultValue: false,
-		requiredSettings: [],
 		frameworks: ALL_FRAMEWORKS,
 	},
 	removeHeight: {
 		displayName: "Remove svg height",
 		defaultValue: false,
-		requiredSettings: [],
 		frameworks: ALL_FRAMEWORKS,
 	},
 	removeViewbox: {
 		displayName: "Remove viewbox",
 		defaultValue: false,
-		requiredSettings: [],
 		frameworks: ALL_FRAMEWORKS,
 	},
 	namedExport: {
 		displayName: "Named export",
 		defaultValue: true,
-		requiredSettings: [],
 		frameworks: JSX_FRAMEWORKS,
 	},
 	removeAllFillAttributes: {
 		displayName: "Remove all 'fill' attributes",
 		defaultValue: false,
-		requiredSettings: [],
 		frameworks: ALL_FRAMEWORKS,
 	},
 	removeAllStrokeAttributes: {
 		displayName: "Remove all 'stroke' attributes",
 		defaultValue: false,
-		requiredSettings: [],
 		frameworks: ALL_FRAMEWORKS,
 	},
 	removeTitle: {
 		displayName: "Remove <title>",
 		defaultValue: false,
-		requiredSettings: [],
 		frameworks: ALL_FRAMEWORKS,
 	},
 	forwardRef: {
 		displayName: "Forward ref",
 		defaultValue: false,
-		requiredSettings: [
-			{
-				optionKey: "props",
-				value: true,
-				framework: FrameworkEnum.SOLID,
-			},
-			{
-				optionKey: "spreadProps",
-				value: false,
-				framework: FrameworkEnum.SOLID,
-			},
-		],
+		disabledWhen: ({ genOptions, framework }) => ({
+			isDisabled:
+				framework === FrameworkEnum.SOLID
+					? !genOptions.props || genOptions.spreadProps
+					: false,
+			reasons: ["{props} must be <ON>", "{spreadProps} must be <OFF>"],
+		}),
 		frameworks: JSX_FRAMEWORKS,
 	},
 };

--- a/shared/types/src/genOptions.ts
+++ b/shared/types/src/genOptions.ts
@@ -1,13 +1,19 @@
 import type { FrameworkEnum } from "./framework";
 
+export interface IGenOptionDisabledData {
+	isDisabled?: boolean;
+	reasons: string[];
+}
+
+type IGenOptionMetadisabledWhenFn = (data: {
+	genOptions: IGenOptions;
+	framework: FrameworkEnum;
+}) => IGenOptionDisabledData;
+
 export type IGenOptionMeta = {
 	displayName: string;
 	defaultValue: boolean;
-	requiredSettings: Array<{
-		optionKey: IGenOptionsMetaKeys;
-		value: boolean;
-		framework?: FrameworkEnum;
-	}>;
+	disabledWhen?: IGenOptionMetadisabledWhenFn;
 	frameworks: FrameworkEnum[];
 };
 


### PR DESCRIPTION
In preparation for #9.
It simplifies the conditional disabling of generation options while also making it more versatile.
I also cleaned up resolving of final options as well as added some tests.