### PR TITLE
Fix parsing of component/file names

### DIFF
--- a/apps/ui/src/lib/componentName.ts
+++ b/apps/ui/src/lib/componentName.ts
@@ -1,5 +1,9 @@
 export const strToComponentName = (str: string) => {
-	const matches = str.trim().match(/[a-zA-Z][a-zA-Z0-9_]*/gm);
+	const matches = str
+		.trim()
+		.replaceAll(/^[0-9]+/gm, "")
+		.match(/[a-zA-Z0-9_]+/gm);
+
 	if (!matches) return "SvgComponent";
 
 	for (const [i, match] of matches.entries()) {
@@ -10,5 +14,5 @@ export const strToComponentName = (str: string) => {
 };
 
 export const isComponentNameValid = (str: string): boolean => {
-	return /^[a-zA-Z][a-zA-Z0-9_]*$/gm.test(str);
+	return /^[A-Z]+/gm.test(str) && /^[a-zA-Z0-9_]+$/gm.test(str);
 };

--- a/apps/ui/src/lib/fileName.ts
+++ b/apps/ui/src/lib/fileName.ts
@@ -14,5 +14,5 @@ export const strToFileName = (_str: string) => {
 };
 
 export const isFileNameValid = (str: string): boolean => {
-	return /^[a-zA-Z][a-zA-Z0-9_\-]*$/gm.test(str);
+	return str.trim().length > 0;
 };

--- a/apps/ui/src/modules/Component/Inputs.tsx
+++ b/apps/ui/src/modules/Component/Inputs.tsx
@@ -61,7 +61,7 @@ export const ComponentInputs = () => {
 				/>
 				<Input
 					label="File name"
-					value={compCtx.data.fileName}
+					defaultValue={compCtx.data.fileName}
 					onInput={updateFileName}
 					errors={errors.fileName}
 				/>

--- a/apps/ui/tests/componentName.test.ts
+++ b/apps/ui/tests/componentName.test.ts
@@ -1,16 +1,20 @@
-import { strToComponentName } from "@lib";
+import { isComponentNameValid, strToComponentName } from "@lib";
 import { describe, expect, test } from "vitest";
 
 describe("util: string to component name", () => {
 	const testValidName = (name: string) => {
 		test(`returns "${name}" unchanged`, () => {
+			expect(isComponentNameValid(name)).toBe(true);
 			expect(strToComponentName(name)).toBe(name);
 		});
 	};
 
 	const testInvalidName = (name: string, expected: string) => {
 		test(`changes from "${name}" to "${expected}"`, () => {
-			expect(strToComponentName(name)).toBe(expected);
+			expect(isComponentNameValid(name)).toBe(false);
+			const parsedName = strToComponentName(name);
+			expect(parsedName).toBe(expected);
+			expect(isComponentNameValid(parsedName)).toBe(true);
 		});
 	};
 
@@ -18,6 +22,12 @@ describe("util: string to component name", () => {
 	testValidName("Componenticon");
 	testValidName("Componenticon_svg");
 	testValidName("Icon");
+
+	testValidName("ComponentIcon2");
+
+	testInvalidName("icon/video-1", "IconVideo1");
+	testInvalidName("icon/video-2", "IconVideo2");
+	testInvalidName("icon video 2", "IconVideo2");
 
 	testInvalidName("icon", "Icon");
 	testInvalidName("component Icon", "ComponentIcon");
@@ -27,6 +37,6 @@ describe("util: string to component name", () => {
 	testInvalidName("componenticon", "Componenticon");
 	testInvalidName("component_icon", "Component_icon");
 	testInvalidName("component:icon", "ComponentIcon");
-	testInvalidName("2component:_icon1", "ComponentIcon1");
+	testInvalidName("2component:_icon1", "Component_icon1");
 	testInvalidName("12complex_icon:svg-test:", "Complex_iconSvgTest");
 });


### PR DESCRIPTION
fix for: #7.
I also made component name validity check stricter. On the other hand file names can now be anything but an empty string.