### PR TITLE
Add 3 generation options for class attribute

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -90,6 +90,7 @@ export const App = () => {
 											tmpFrameworkSvgs[frameworkKey][compIdx].genError =
 												e.toString();
 
+											console.log(e);
 											reject(e);
 										}
 									}),
@@ -142,7 +143,7 @@ export const App = () => {
 						resolve();
 					} catch (e) {
 						reject(e);
-
+						console.log(e);
 						setFrameworkComponents(framework, (c) => c === comp, {
 							genError: e.toString(),
 							status: ComponentStatus.ERROR,

--- a/apps/ui/src/lib/svgo/generateOptimizedSvg.ts
+++ b/apps/ui/src/lib/svgo/generateOptimizedSvg.ts
@@ -8,6 +8,7 @@ import {
 	insertValues,
 	removeAttributes,
 	removeUnknownsAndDefaults,
+	smartClasses,
 	svgoDefaultPreset,
 	toJsx,
 } from "./plugins";
@@ -67,6 +68,8 @@ export const generateOptimizedSvg = (opts: ISvgoOpts): IResult => {
 		plugins: [
 			// insertValues should be first so we can capture defaultValues
 			insertValues(ctx),
+			// smartClases must run before svgoDefaultPreset so that it can access svg ids
+			smartClasses(ctx),
 			svgoDefaultPreset(ctx),
 			removeUnknownsAndDefaults(ctx),
 			iconMode(ctx),

--- a/apps/ui/src/lib/svgo/generateOptimizedSvg.ts
+++ b/apps/ui/src/lib/svgo/generateOptimizedSvg.ts
@@ -8,7 +8,7 @@ import {
 	insertValues,
 	removeAttributes,
 	removeUnknownsAndDefaults,
-	smartClasses,
+	insertClasses,
 	svgoDefaultPreset,
 	toJsx,
 } from "./plugins";
@@ -68,8 +68,8 @@ export const generateOptimizedSvg = (opts: ISvgoOpts): IResult => {
 		plugins: [
 			// insertValues should be first so we can capture defaultValues
 			insertValues(ctx),
-			// smartClases must run before svgoDefaultPreset so that it can access svg ids
-			smartClasses(ctx),
+			// insertClasses must run before svgoDefaultPreset so that it can access svg ids
+			insertClasses(ctx),
 			svgoDefaultPreset(ctx),
 			removeUnknownsAndDefaults(ctx),
 			iconMode(ctx),

--- a/apps/ui/src/lib/svgo/generateOptimizedSvg.ts
+++ b/apps/ui/src/lib/svgo/generateOptimizedSvg.ts
@@ -3,6 +3,7 @@ import { REACT_FRAMEWORKS } from "@shared/lib";
 import type { ISvgOptimizationInfo, ISvgoCtx, ISvgoOpts } from "@shared/types";
 import { optimize } from "svgo";
 import {
+	iconMode,
 	insertPlaceholders,
 	insertValues,
 	removeAttributes,
@@ -10,7 +11,6 @@ import {
 	svgoDefaultPreset,
 	toJsx,
 } from "./plugins";
-import { iconMode } from "./plugins/iconMode";
 
 interface IResult extends ISvgOptimizationInfo {
 	svgCode: string;

--- a/apps/ui/src/lib/svgo/parseClassAttr.ts
+++ b/apps/ui/src/lib/svgo/parseClassAttr.ts
@@ -1,0 +1,21 @@
+export const parseClassAttr = (className: string) => {
+	let result = "";
+
+	let canAddNumbers = false;
+	for (let i = 0; i < className.length; i++) {
+		const char = className[i];
+
+		if (/[0-9]/.test(char)) {
+			if (canAddNumbers) {
+				result += char;
+			}
+		} else if (/[_a-zA-Z-]/.test(char)) {
+			canAddNumbers = true;
+			result += char;
+		} else if (char !== " ") {
+			result += `\\${char}`;
+		}
+	}
+
+	return result;
+};

--- a/apps/ui/src/lib/svgo/plugins/index.ts
+++ b/apps/ui/src/lib/svgo/plugins/index.ts
@@ -4,3 +4,4 @@ export * from "./insertValues";
 export * from "./toJsx";
 export * from "./defaultPreset";
 export * from "./removeUnknownsAndDefaults";
+export * from "./iconMode";

--- a/apps/ui/src/lib/svgo/plugins/index.ts
+++ b/apps/ui/src/lib/svgo/plugins/index.ts
@@ -5,4 +5,4 @@ export * from "./toJsx";
 export * from "./defaultPreset";
 export * from "./removeUnknownsAndDefaults";
 export * from "./iconMode";
-export * from "./smartClasses";
+export * from "./insertClasses";

--- a/apps/ui/src/lib/svgo/plugins/index.ts
+++ b/apps/ui/src/lib/svgo/plugins/index.ts
@@ -5,3 +5,4 @@ export * from "./toJsx";
 export * from "./defaultPreset";
 export * from "./removeUnknownsAndDefaults";
 export * from "./iconMode";
+export * from "./smartClasses";

--- a/apps/ui/src/lib/svgo/plugins/insertClasses.ts
+++ b/apps/ui/src/lib/svgo/plugins/insertClasses.ts
@@ -3,12 +3,12 @@ import type { XastChild, XastElement } from "svgo/lib/types";
 import { getRootNodes } from "../getRootNodes";
 import { parseClassAttr } from "../parseClassAttr";
 
-export const smartClasses: ISvgoPluginFn = ({ genOptions, isReact }) => {
+export const insertClasses: ISvgoPluginFn = ({ genOptions, isReact }) => {
 	const goThroughChildren = (node: XastChild, accClass = "") => {
 		if (node.type !== "element") return;
 
 		if (node.attributes.id) {
-			if (genOptions.smartClassesExact) {
+			if (!genOptions.bemClasses) {
 				setClassAttr(node, parseClassAttr(node.attributes.id));
 			} else {
 				// biome-ignore lint lint/style/noParameterAssign:
@@ -29,11 +29,13 @@ export const smartClasses: ISvgoPluginFn = ({ genOptions, isReact }) => {
 	};
 
 	return {
-		name: "smart-classes",
+		name: "insert-classes",
 		fn: () => ({
 			root: {
 				enter: (root) => {
-					if (!genOptions.smartClasses) return;
+					if (!genOptions.nodesNamesToClasses) {
+						return;
+					}
 
 					const svgNodes = getRootNodes(root);
 					for (const svgNode of svgNodes) {
@@ -55,7 +57,7 @@ export const smartClasses: ISvgoPluginFn = ({ genOptions, isReact }) => {
 								}
 							}
 
-							if (!genOptions.smartClassesOnlySvg) {
+							if (!genOptions.classOnlyOnSvg) {
 								for (const child of svgNode.children) {
 									goThroughChildren(child, baseClass);
 								}

--- a/apps/ui/src/lib/svgo/plugins/smartClasses.ts
+++ b/apps/ui/src/lib/svgo/plugins/smartClasses.ts
@@ -1,0 +1,69 @@
+import type { ISvgoPluginFn } from "@shared/types";
+import type { XastChild, XastElement } from "svgo/lib/types";
+import { getRootNodes } from "../getRootNodes";
+import { parseClassAttr } from "../parseClassAttr";
+
+export const smartClasses: ISvgoPluginFn = ({ genOptions, isReact }) => {
+	const goThroughChildren = (node: XastChild, accClass = "") => {
+		if (node.type !== "element") return;
+
+		if (node.attributes.id) {
+			if (genOptions.smartClassesExact) {
+				setClassAttr(node, parseClassAttr(node.attributes.id));
+			} else {
+				// biome-ignore lint lint/style/noParameterAssign:
+				accClass += `${accClass.length > 0 ? "__" : ""}${parseClassAttr(node.attributes.id)}`;
+				setClassAttr(node, accClass);
+			}
+			// biome-ignore lint lint/performance/noDelete:
+			delete node.attributes.id;
+
+			for (const child of node.children) {
+				goThroughChildren(child, accClass);
+			}
+		}
+	};
+
+	const setClassAttr = (node: XastElement, value: string) => {
+		node.attributes[isReact ? "className" : "class"] = value;
+	};
+
+	return {
+		name: "smart-classes",
+		fn: () => ({
+			root: {
+				enter: (root) => {
+					if (!genOptions.smartClasses) return;
+
+					const svgNodes = getRootNodes(root);
+					for (const svgNode of svgNodes) {
+						let baseClass = "";
+						if (svgNode.children.length > 0) {
+							const node = svgNode.children.filter(
+								(e) => e.type === "element" && e.name !== "title",
+							)[0] as XastElement | null;
+
+							if (node?.attributes.id) {
+								baseClass = parseClassAttr(node.attributes.id);
+
+								setClassAttr(svgNode, baseClass);
+								if (node.name === "g") {
+									svgNode.children = node.children;
+								} else {
+									// biome-ignore lint lint/performance/noDelete:
+									delete node.attributes.id;
+								}
+							}
+
+							if (!genOptions.smartClassesOnlySvg) {
+								for (const child of svgNode.children) {
+									goThroughChildren(child, baseClass);
+								}
+							}
+						}
+					}
+				},
+			},
+		}),
+	};
+};

--- a/apps/ui/tests/genOptions/smartClasses.test.ts
+++ b/apps/ui/tests/genOptions/smartClasses.test.ts
@@ -1,0 +1,126 @@
+import { REACT_FRAMEWORKS } from "@shared/lib";
+import { FrameworkEnum, type IComponent } from "@shared/types";
+import { parseClassAttr } from "src/lib/svgo/parseClassAttr";
+import type { ElementNode } from "svg-parser";
+import { getTestClassAttr } from "tests/lib/getTestClassAttr";
+import { describe, expect, test } from "vitest";
+import {
+	TEST_SVGS,
+	TEST_SVG_GROUP_ID,
+	TEST_SVG_GROUP_ID_PARSED,
+	TEST_SVG_RECT_1_ID,
+	TEST_SVG_RECT_1_ID_PARSED,
+	TEST_SVG_RECT_2_ID,
+	TEST_SVG_RECT_2_ID_PARSED,
+} from "../lib/consts";
+import { prepareCompTestCtx } from "../lib/prepareCompTestCtx";
+
+describe("smart classes", () => {
+	test("parse class attribute", () => {
+		expect(parseClassAttr("Group 1")).toBe("Group1");
+		expect(parseClassAttr("Group_1")).toBe("Group_1");
+		expect(parseClassAttr("21Group_1")).toBe("Group_1");
+		expect(parseClassAttr("21Group:1")).toBe("Group\\:1");
+		expect(parseClassAttr("Group 1 (special)")).toBe("Group1\\(special\\)");
+		expect(parseClassAttr("Group_1__Rectangle_1")).toBe("Group_1__Rectangle_1");
+
+		expect(parseClassAttr(TEST_SVG_GROUP_ID)).toBe(TEST_SVG_GROUP_ID_PARSED);
+		expect(parseClassAttr(TEST_SVG_RECT_1_ID)).toBe(TEST_SVG_RECT_1_ID_PARSED);
+		expect(parseClassAttr(TEST_SVG_RECT_2_ID)).toBe(TEST_SVG_RECT_2_ID_PARSED);
+	});
+
+	const checkCodeForClasses = (
+		component: IComponent,
+		framework: FrameworkEnum,
+	) => {
+		const attrName = REACT_FRAMEWORKS.includes(framework)
+			? "className"
+			: "class";
+
+		return component.code.match(new RegExp(`${attrName}=`, "gm"));
+	};
+
+	for (const framework of Object.values(FrameworkEnum)) {
+		describe(framework, () => {
+			describe("Group with 2 rects", () => {
+				test("should have BEM classes on <svg> and 2 <rects>", async () => {
+					const { svgEl, component } = await prepareCompTestCtx({
+						svgCode: TEST_SVGS.GROUP_2_RECTS_WITH_IDS,
+						framework,
+						genOptions: {
+							smartClasses: true,
+						},
+					});
+
+					expect(checkCodeForClasses(component, framework)).toHaveLength(3);
+					expect(getTestClassAttr(svgEl, framework)).toBe(
+						TEST_SVG_GROUP_ID_PARSED,
+					);
+
+					expect(
+						getTestClassAttr(svgEl.children[0] as ElementNode, framework),
+					).toBe(`${TEST_SVG_GROUP_ID_PARSED}__${TEST_SVG_RECT_1_ID_PARSED}`);
+					expect(
+						getTestClassAttr(svgEl.children[1] as ElementNode, framework),
+					).toBe(`${TEST_SVG_GROUP_ID_PARSED}__${TEST_SVG_RECT_2_ID_PARSED}`);
+				});
+
+				test("should have exact classes on <svg> and 2 <rects>", async () => {
+					const { svgEl, component } = await prepareCompTestCtx({
+						svgCode: TEST_SVGS.GROUP_2_RECTS_WITH_IDS,
+						framework,
+						genOptions: {
+							smartClasses: true,
+							smartClassesExact: true,
+						},
+					});
+
+					expect(checkCodeForClasses(component, framework)).toHaveLength(3);
+					expect(getTestClassAttr(svgEl, framework)).toBe(
+						TEST_SVG_GROUP_ID_PARSED,
+					);
+
+					expect(
+						getTestClassAttr(svgEl.children[0] as ElementNode, framework),
+					).toBe(TEST_SVG_RECT_1_ID_PARSED);
+					expect(
+						getTestClassAttr(svgEl.children[1] as ElementNode, framework),
+					).toBe(TEST_SVG_RECT_2_ID_PARSED);
+				});
+
+				test("should have class only on <svg>", async () => {
+					const { svgEl, component } = await prepareCompTestCtx({
+						svgCode: TEST_SVGS.GROUP_2_RECTS_WITH_IDS,
+						framework,
+						genOptions: {
+							smartClasses: true,
+							smartClassesOnlySvg: true,
+						},
+					});
+
+					expect(checkCodeForClasses(component, framework)).toHaveLength(1);
+					expect(getTestClassAttr(svgEl, framework)).toBe(
+						TEST_SVG_GROUP_ID_PARSED,
+					);
+				});
+			});
+
+			describe("One rect", () => {
+				test("should have class on <svg>", async () => {
+					const { svgEl, component } = await prepareCompTestCtx({
+						svgCode: TEST_SVGS.RECTS_WITH_ID,
+						framework,
+						genOptions: {
+							smartClasses: true,
+						},
+					});
+
+					expect(checkCodeForClasses(component, framework)).toHaveLength(1);
+					expect(getTestClassAttr(svgEl, framework)).toBe(
+						TEST_SVG_RECT_1_ID_PARSED,
+					);
+				});
+			});
+		});
+	}
+});

--- a/apps/ui/tests/genOptions/smartClasses.test.ts
+++ b/apps/ui/tests/genOptions/smartClasses.test.ts
@@ -48,7 +48,8 @@ describe("smart classes", () => {
 						svgCode: TEST_SVGS.GROUP_2_RECTS_WITH_IDS,
 						framework,
 						genOptions: {
-							smartClasses: true,
+							nodesNamesToClasses: true,
+              bemClasses: true,
 						},
 					});
 
@@ -70,8 +71,7 @@ describe("smart classes", () => {
 						svgCode: TEST_SVGS.GROUP_2_RECTS_WITH_IDS,
 						framework,
 						genOptions: {
-							smartClasses: true,
-							smartClassesExact: true,
+							nodesNamesToClasses: true,
 						},
 					});
 
@@ -88,13 +88,31 @@ describe("smart classes", () => {
 					).toBe(TEST_SVG_RECT_2_ID_PARSED);
 				});
 
-				test("should have class only on <svg>", async () => {
+
+				test("should have BEM class only on <svg>", async () => {
 					const { svgEl, component } = await prepareCompTestCtx({
 						svgCode: TEST_SVGS.GROUP_2_RECTS_WITH_IDS,
 						framework,
 						genOptions: {
-							smartClasses: true,
-							smartClassesOnlySvg: true,
+              nodesNamesToClasses: true,
+							bemClasses: true,
+							classOnlyOnSvg: true,
+						},
+					});
+
+					expect(checkCodeForClasses(component, framework)).toHaveLength(1);
+					expect(getTestClassAttr(svgEl, framework)).toBe(
+						TEST_SVG_GROUP_ID_PARSED,
+					);
+				});
+
+				test("should have exact class only on <svg>", async () => {
+					const { svgEl, component } = await prepareCompTestCtx({
+						svgCode: TEST_SVGS.GROUP_2_RECTS_WITH_IDS,
+						framework,
+						genOptions: {
+							nodesNamesToClasses: true,
+							classOnlyOnSvg: true,
 						},
 					});
 
@@ -105,13 +123,13 @@ describe("smart classes", () => {
 				});
 			});
 
-			describe("One rect", () => {
+			describe("1 rect", () => {
 				test("should have class on <svg>", async () => {
 					const { svgEl, component } = await prepareCompTestCtx({
 						svgCode: TEST_SVGS.RECTS_WITH_ID,
 						framework,
 						genOptions: {
-							smartClasses: true,
+              nodesNamesToClasses: true
 						},
 					});
 

--- a/apps/ui/tests/lib/consts.ts
+++ b/apps/ui/tests/lib/consts.ts
@@ -5,12 +5,22 @@ export const TEST_SVG_WIDTH = 144;
 export const TEST_SVG_HEIGHT = 144;
 export const TEST_SVG_VIEWBOX = "0 0 144 144";
 
+export const TEST_SVG_GROUP_ID = "Group 1";
+export const TEST_SVG_GROUP_ID_PARSED = "Group1";
+export const TEST_SVG_RECT_1_ID = "1Rectangle_14";
+export const TEST_SVG_RECT_1_ID_PARSED = "Rectangle_14";
+export const TEST_SVG_RECT_2_ID = "Rectangle-17";
+export const TEST_SVG_RECT_2_ID_PARSED = "Rectangle-17";
+
 export const TEST_SVGS = {
 	SIMPLE_RECT: `<svg width="${TEST_SVG_WIDTH}" height="${TEST_SVG_HEIGHT}" viewBox="${TEST_SVG_VIEWBOX}" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="144" height="144" fill="#FF00F2" stroke="red" /></svg>`,
 	SIMPLE_RECT_OPTIMIZED: `<svg xmlns="http://www.w3.org/2000/svg" width="${TEST_SVG_WIDTH}" height="${TEST_SVG_HEIGHT}" fill="none" viewBox="${TEST_SVG_VIEWBOX}" SPP_SPREAD_PROPS="" SPP_REF=""><path fill="#FF00F2" stroke="red" d="M0 0h144v144H0z"/></svg>`,
 
 	SIMPLE_RECT_WITH_TITLE: `<svg width="${TEST_SVG_WIDTH}" height="${TEST_SVG_HEIGHT}" viewBox="${TEST_SVG_VIEWBOX}" fill="none" xmlns="http://www.w3.org/2000/svg"><title>${TEST_SVG_TITLE}</title><rect width="144" height="144" fill="#FF00F2"/></svg>`,
 	SIMPLE_RECT_EMPTY_TITLE: `<svg width="${TEST_SVG_WIDTH}" height="${TEST_SVG_HEIGHT}" viewBox="${TEST_SVG_VIEWBOX}" fill="none" xmlns="http://www.w3.org/2000/svg"><title></title><rect width="144" height="144" fill="#FF00F2"/></svg>`,
+
+	GROUP_2_RECTS_WITH_IDS: `<svg width="${TEST_SVG_WIDTH}" height="${TEST_SVG_HEIGHT}" viewBox="${TEST_SVG_VIEWBOX}" fill="none" xmlns="http://www.w3.org/2000/svg"><g id="${TEST_SVG_GROUP_ID}"><rect id="${TEST_SVG_RECT_1_ID}" width="144" height="144" fill="#FF00F2"/><rect id="${TEST_SVG_RECT_2_ID}" width="144" height="144" fill="#00FFF2"/></g></svg>`,
+	RECTS_WITH_ID: `<svg width="${TEST_SVG_WIDTH}" height="${TEST_SVG_HEIGHT}" viewBox="${TEST_SVG_VIEWBOX}" fill="none" xmlns="http://www.w3.org/2000/svg"><rect id="${TEST_SVG_RECT_1_ID}" width="144" height="144" fill="#FF00F2"/></svg>`,
 };
 
 export const OG_SVG_ID = "og-svg";

--- a/apps/ui/tests/lib/getTestClassAttr.ts
+++ b/apps/ui/tests/lib/getTestClassAttr.ts
@@ -1,0 +1,12 @@
+import { REACT_FRAMEWORKS } from "@shared/lib";
+import type { FrameworkEnum } from "@shared/types";
+import type { ElementNode } from "svg-parser";
+
+export const getTestClassAttr = (
+	node: ElementNode,
+	framework: FrameworkEnum,
+) => {
+	const attrName = REACT_FRAMEWORKS.includes(framework) ? "className" : "class";
+
+	return node.properties[attrName];
+};

--- a/apps/ui/tests/lib/prepareCompTestCtx.test.ts
+++ b/apps/ui/tests/lib/prepareCompTestCtx.test.ts
@@ -1,28 +1,37 @@
 import { FrameworkEnum } from "@shared/types";
+import type { ElementNode } from "svg-parser";
 import { describe, expect, test } from "vitest";
 import {
 	TEST_SVGS,
+	TEST_SVG_GROUP_ID,
 	TEST_SVG_HEIGHT,
+	TEST_SVG_RECT_1_ID,
+	TEST_SVG_RECT_2_ID,
 	TEST_SVG_TITLE,
 	TEST_SVG_VIEWBOX,
 	TEST_SVG_WIDTH,
 } from "../lib/consts";
-import { prepareCompTestCtx } from "../lib/prepareCompTestCtx";
+import {
+	type ICompTestCtx,
+	prepareCompTestCtx,
+} from "../lib/prepareCompTestCtx";
 import { getTestTitleElement, getTestTitleValue } from "./getTestTitleValue";
 
 describe("test util: prepare component test context", () => {
-	const testSVG = (
-		name: string,
-		svgCode: string,
-		titleStatus: "without" | "with" | "with_empty",
-	) => {
+	interface ITestOpts {
+		name: string;
+		svgCode: string;
+		additionalTests?: Array<(ctx: ICompTestCtx) => void>;
+	}
+	const testSVG = ({ name, svgCode, additionalTests }: ITestOpts) => {
 		for (const framework of Object.values(FrameworkEnum)) {
 			test(`[${framework}] ${name} should have properties`, async () => {
-				const { svgEl, beforeSvgEl } = await prepareCompTestCtx({
+				const ctx = await prepareCompTestCtx({
 					svgCode,
 					framework,
 					genOptions: {},
 				});
+				const { beforeSvgEl } = ctx;
 
 				expect(beforeSvgEl.properties).toHaveProperty("width");
 				expect(beforeSvgEl.properties).toHaveProperty("height");
@@ -31,42 +40,95 @@ describe("test util: prepare component test context", () => {
 				expect(beforeSvgEl.properties.height).toBe(TEST_SVG_HEIGHT);
 				expect(beforeSvgEl.properties.viewBox).toBe(TEST_SVG_VIEWBOX);
 
-				expect(svgEl.properties).toHaveProperty("width");
-				expect(svgEl.properties).toHaveProperty("height");
-				expect(svgEl.properties).toHaveProperty("viewBox");
-				expect(svgEl.properties.width).toBe(TEST_SVG_WIDTH);
-				expect(svgEl.properties.height).toBe(TEST_SVG_HEIGHT);
-				expect(svgEl.properties.viewBox).toBe(TEST_SVG_VIEWBOX);
-
-				if (framework === FrameworkEnum.REACT_NATIVE) {
-					expect(getTestTitleElement(svgEl)).toBeNull();
-					expect(getTestTitleValue(svgEl)).toBeNull();
-				} else {
-					if (titleStatus === "without") {
-						expect(getTestTitleElement(beforeSvgEl)).toBeNull();
-						expect(getTestTitleElement(svgEl)).toBeNull();
-					} else if (titleStatus === "with") {
-						expect(getTestTitleElement(beforeSvgEl)).toBeDefined();
-						expect(getTestTitleValue(beforeSvgEl)).toBe(TEST_SVG_TITLE);
-						expect(getTestTitleElement(svgEl)).toBeDefined();
-						expect(getTestTitleValue(svgEl)).toBe(TEST_SVG_TITLE);
-					} else if (titleStatus === "with_empty") {
-						expect(getTestTitleElement(beforeSvgEl)).toBeDefined();
-						expect(getTestTitleValue(beforeSvgEl)).toBeNull();
-						expect(getTestTitleElement(svgEl)).toBeDefined();
-						expect(getTestTitleValue(svgEl)).toBeNull();
+				if (additionalTests) {
+					for (const execTests of additionalTests) {
+						execTests(ctx);
 					}
 				}
 			});
 		}
 	};
 
-	testSVG("SIMPLE_RECT", TEST_SVGS.SIMPLE_RECT, "without");
-	testSVG("SIMPLE_RECT_OPTIMIZED", TEST_SVGS.SIMPLE_RECT_OPTIMIZED, "without");
-	testSVG("SIMPLE_RECT_WITH_TITLE", TEST_SVGS.SIMPLE_RECT_WITH_TITLE, "with");
-	testSVG(
-		"SIMPLE_RECT_EMPTY_TITLE",
-		TEST_SVGS.SIMPLE_RECT_EMPTY_TITLE,
-		"with_empty",
-	);
+	const testNoTitle = ({ beforeSvgEl }: ICompTestCtx) => {
+		expect(getTestTitleElement(beforeSvgEl)).toBeNull();
+	};
+
+	const testWithTitle = ({ beforeSvgEl }: ICompTestCtx) => {
+		expect(getTestTitleElement(beforeSvgEl)).toBeDefined();
+		expect(getTestTitleValue(beforeSvgEl)).toBe(TEST_SVG_TITLE);
+	};
+
+	const testWithEmptyTitle = ({ beforeSvgEl }: ICompTestCtx) => {
+		expect(getTestTitleElement(beforeSvgEl)).toBeDefined();
+		expect(getTestTitleValue(beforeSvgEl)).toBeNull();
+	};
+
+	testSVG({
+		name: "SIMPLE_RECT",
+		svgCode: TEST_SVGS.SIMPLE_RECT,
+		additionalTests: [testNoTitle],
+	});
+
+	testSVG({
+		name: "SIMPLE_RECT_OPTIMIZED",
+		svgCode: TEST_SVGS.SIMPLE_RECT_OPTIMIZED,
+		additionalTests: [testNoTitle],
+	});
+
+	testSVG({
+		name: "SIMPLE_RECT_WITH_TITLE",
+		svgCode: TEST_SVGS.SIMPLE_RECT_WITH_TITLE,
+		additionalTests: [testWithTitle],
+	});
+
+	testSVG({
+		name: "SIMPLE_RECT_EMPTY_TITLE",
+		svgCode: TEST_SVGS.SIMPLE_RECT_EMPTY_TITLE,
+		additionalTests: [testWithEmptyTitle],
+	});
+
+	const testClassesWithGroupAndRects = ({ beforeSvgEl }: ICompTestCtx) => {
+		expect(beforeSvgEl.children).toHaveLength(1);
+
+		const group = beforeSvgEl.children[0] as ElementNode;
+		expect(group).toBeTypeOf("object");
+		expect(group.type).toBe("element");
+		expect(group.tagName).toBe("g");
+		expect(group.properties.id).toBe(TEST_SVG_GROUP_ID);
+		expect(group.children).toHaveLength(2);
+
+		const rect1 = group.children[0] as ElementNode;
+		expect(rect1).toBeTypeOf("object");
+		expect(rect1.type).toBe("element");
+		expect(rect1.tagName).toBe("rect");
+		expect(rect1.properties.id).toBe(TEST_SVG_RECT_1_ID);
+
+		const rect2 = group.children[1] as ElementNode;
+		expect(rect2).toBeTypeOf("object");
+		expect(rect2.type).toBe("element");
+		expect(rect2.tagName).toBe("rect");
+		expect(rect2.properties.id).toBe(TEST_SVG_RECT_2_ID);
+	};
+
+	const testClassesRect = ({ beforeSvgEl }: ICompTestCtx) => {
+		expect(beforeSvgEl.children).toHaveLength(1);
+
+		const rect1 = beforeSvgEl.children[0] as ElementNode;
+		expect(rect1).toBeTypeOf("object");
+		expect(rect1.type).toBe("element");
+		expect(rect1.tagName).toBe("rect");
+		expect(rect1.properties.id).toBe(TEST_SVG_RECT_1_ID);
+	};
+
+	testSVG({
+		name: "GROUP_2_RECTS_WITH_IDS",
+		svgCode: TEST_SVGS.GROUP_2_RECTS_WITH_IDS,
+		additionalTests: [testClassesWithGroupAndRects],
+	});
+
+	testSVG({
+		name: "RECTS_WITH_ID",
+		svgCode: TEST_SVGS.RECTS_WITH_ID,
+		additionalTests: [testClassesRect],
+	});
 });

--- a/shared/lib/src/genOptions.ts
+++ b/shared/lib/src/genOptions.ts
@@ -111,26 +111,26 @@ export const GEN_OPTIONS_METADATA: IGenOptionsMeta = {
 		}),
 		frameworks: JSX_FRAMEWORKS,
 	},
-	smartClasses: {
-		displayName: "Smart classes",
+	nodesNamesToClasses: {
+		displayName: "Nodes' names to classes",
 		defaultValue: false,
 		frameworks: ALL_FRAMEWORKS,
 	},
-	smartClassesOnlySvg: {
-		displayName: "Class only on <svg>",
+	bemClasses: {
+		displayName: "BEM classes",
 		defaultValue: false,
 		disabledWhen: ({ genOptions }) => ({
-			isDisabled: !genOptions.smartClasses,
-			reasons: ["{smartClasses} must be <ON>"],
+			isDisabled: !genOptions.nodesNamesToClasses,
+			reasons: ["{nodesNamesToClasses} must be <ON>"],
 		}),
 		frameworks: ALL_FRAMEWORKS,
 	},
-	smartClassesExact: {
-		displayName: "Smart classes exact",
+	classOnlyOnSvg: {
+		displayName: "Class only on <svg>",
 		defaultValue: false,
 		disabledWhen: ({ genOptions }) => ({
-			isDisabled: !genOptions.smartClasses,
-			reasons: ["{smartClasses} must be <ON>"],
+			isDisabled: !genOptions.bemClasses && !genOptions.nodesNamesToClasses,
+			reasons: ["{nodesNamesToClasses} must be <ON>"],
 		}),
 		frameworks: ALL_FRAMEWORKS,
 	},

--- a/shared/lib/src/genOptions.ts
+++ b/shared/lib/src/genOptions.ts
@@ -111,6 +111,29 @@ export const GEN_OPTIONS_METADATA: IGenOptionsMeta = {
 		}),
 		frameworks: JSX_FRAMEWORKS,
 	},
+	smartClasses: {
+		displayName: "Smart classes",
+		defaultValue: false,
+		frameworks: ALL_FRAMEWORKS,
+	},
+	smartClassesOnlySvg: {
+		displayName: "Class only on <svg>",
+		defaultValue: false,
+		disabledWhen: ({ genOptions }) => ({
+			isDisabled: !genOptions.smartClasses,
+			reasons: ["{smartClasses} must be <ON>"],
+		}),
+		frameworks: ALL_FRAMEWORKS,
+	},
+	smartClassesExact: {
+		displayName: "Smart classes exact",
+		defaultValue: false,
+		disabledWhen: ({ genOptions }) => ({
+			isDisabled: !genOptions.smartClasses,
+			reasons: ["{smartClasses} must be <ON>"],
+		}),
+		frameworks: ALL_FRAMEWORKS,
+	},
 };
 
 export const makeDefaultGenOptions = (): IGenOptions => {

--- a/shared/types/src/genOptions.ts
+++ b/shared/types/src/genOptions.ts
@@ -25,9 +25,9 @@ export interface IGenOptionsMeta {
 	removeAllFillAttributes: IGenOptionMeta;
 	removeAllStrokeAttributes: IGenOptionMeta;
 	iconMode: IGenOptionMeta;
-	smartClasses: IGenOptionMeta;
-	smartClassesOnlySvg: IGenOptionMeta;
-	smartClassesExact: IGenOptionMeta;
+	bemClasses: IGenOptionMeta;
+	classOnlyOnSvg: IGenOptionMeta;
+	nodesNamesToClasses: IGenOptionMeta;
 
 	// Component
 	props: IGenOptionMeta;

--- a/shared/types/src/genOptions.ts
+++ b/shared/types/src/genOptions.ts
@@ -25,6 +25,9 @@ export interface IGenOptionsMeta {
 	removeAllFillAttributes: IGenOptionMeta;
 	removeAllStrokeAttributes: IGenOptionMeta;
 	iconMode: IGenOptionMeta;
+	smartClasses: IGenOptionMeta;
+	smartClassesOnlySvg: IGenOptionMeta;
+	smartClassesExact: IGenOptionMeta;
 
 	// Component
 	props: IGenOptionMeta;


### PR DESCRIPTION
for #8 
Add 3 new generation options:
- Nodes' names to classes
Transforms names of the figma nodes that were exported into class attributes
- BEM classes
requires: Nodes' names to classes to be ON
Makes class names follow the [BEM](https://en.bem.info/methodology/css/) methodology
- Class only on <svg>
requires: Nodes' names to classes to be ON
Inserts class to just <svg> element