### PR TITLE
Allow plugin to run in figma's Dev Mode™

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,14 +6,10 @@
   "main": "dist/plugin/index.js",
   "ui": "dist/ui/index.html",
   "documentAccess": "dynamic-page",
-  "editorType": [
-    "figma"
-  ],
-  "capabilities": [],
+  "editorType": ["figma", "dev"],
+  "capabilities": ["inspect"],
   "enableProposedApi": false,
   "networkAccess": {
-    "allowedDomains": [
-      "none"
-    ]
+    "allowedDomains": ["none"]
   }
 }


### PR DESCRIPTION
This plugin has saved me countless times, however, it can't save my coworkers as they do not have a designer seat in Figma. 

My change enables the plugin to run in Figma's Dev Mode™, with the only difference being that it is rendered inside the inspect panel instead of a floating window.